### PR TITLE
feat: support a28 guids on import

### DIFF
--- a/Runtime/Scripts/Export/GltfWriter.cs
+++ b/Runtime/Scripts/Export/GltfWriter.cs
@@ -1900,7 +1900,7 @@ namespace GLTFast.Export
             var node = new Node
             {
                 name = name,
-                guid = guid
+                extras = new Node.Extras(guid)
             };
             if (translation.HasValue && !translation.Equals(float3.zero))
             {

--- a/Runtime/Scripts/GameObjectInstantiator.cs
+++ b/Runtime/Scripts/GameObjectInstantiator.cs
@@ -22,6 +22,7 @@ using UnityEngine.Profiling;
 using Camera = UnityEngine.Camera;
 using Material = UnityEngine.Material;
 using Mesh = UnityEngine.Mesh;
+using A28;
 
 // #if UNITY_EDITOR && UNITY_ANIMATION
 // using UnityEditor.Animations;
@@ -195,7 +196,8 @@ namespace GLTFast
             uint? parentIndex,
             Vector3 position,
             Quaternion rotation,
-            Vector3 scale
+            Vector3 scale,
+            string guid
         )
         {
             var go = new GameObject();
@@ -210,6 +212,10 @@ namespace GLTFast
             go.transform.SetParent(
                 parentIndex.HasValue ? m_Nodes[parentIndex.Value].transform : SceneTransform,
                 false);
+
+            if (guid == null) return;
+            var guidComponent = go.AddComponent<GuidComponent>();
+            guidComponent.GuidString = guid;
         }
 
         /// <inheritdoc />

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -2275,7 +2275,7 @@ namespace GLTFast
                 Profiler.BeginSample("CreateHierarchy");
                 var node = m_GltfRoot.nodes[nodeIndex];
                 node.GetTransform(out var position, out var rotation, out var scale);
-                instantiator.CreateNode(nodeIndex, parentIndex, position, rotation, scale);
+                instantiator.CreateNode(nodeIndex, parentIndex, position, rotation, scale, node.extras.guid);
                 Profiler.EndSample();
             }
 

--- a/Runtime/Scripts/IInstantiator.cs
+++ b/Runtime/Scripts/IInstantiator.cs
@@ -63,7 +63,8 @@ namespace GLTFast
             uint? parentIndex,
             Vector3 position,
             Quaternion rotation,
-            Vector3 scale
+            Vector3 scale,
+            string guid
             );
 
         /// <summary>

--- a/Runtime/Scripts/Schema/Node.cs
+++ b/Runtime/Scripts/Schema/Node.cs
@@ -73,7 +73,18 @@ namespace GLTFast.Schema
         /// <inheritdoc cref="NodeExtensions"/>
         public NodeExtensions extensions;
 
-        public string guid = null;
+        public Extras extras;
+
+        [System.Serializable]
+        public class Extras
+        {
+            public string guid;
+
+            public Extras(string guid)
+            {
+                this.guid = guid;
+            }
+        }
 
         internal void GltfSerialize(JsonWriter writer)
         {
@@ -126,9 +137,9 @@ namespace GLTFast.Schema
                 extensions.GltfSerialize(writer);
             }
 
-            if (guid != null)
+            if (extras.guid != null)
             {
-                writer.AddGuid(guid);
+                writer.AddGuid(extras.guid);
             }
             writer.Close();
         }

--- a/Tests/Editor/JsonParsingTests.cs
+++ b/Tests/Editor/JsonParsingTests.cs
@@ -471,5 +471,32 @@ namespace GLTFast.Tests
             gltf = JsonParser.ParseJson(@"garbage");
             Assert.IsNull(gltf);
         }
+        
+        [Test]
+        public void A28Guid()
+        {
+            var gltf = JsonParser.ParseJson(@"
+{
+    ""nodes"": [
+        {
+            ""extensions"": {},
+            ""name"": ""Node1"",
+            ""extras"": {""guid"": ""48a855b4b5934f7aa9e0ece96e8fcfaf""}
+        }
+    ]
+}
+"
+            );
+
+            Assert.NotNull(gltf);
+            Assert.NotNull(gltf.nodes, "No nodes");
+            Assert.AreEqual(1, gltf.nodes.Length, "Invalid nodes quantity");
+
+            var node = gltf.nodes[0];
+            Assert.NotNull(node);
+            Assert.NotNull(node.extras);
+            Assert.NotNull(node.extras.guid);
+            Assert.AreEqual(node.extras.guid, "48a855b4b5934f7aa9e0ece96e8fcfaf", "Guid does not match");
+        }
     }
 }


### PR DESCRIPTION
support `guid` in the `extras` and apply them to imported game objects by adding a GuidComponent to them and assigning the GUID.

see https://github.com/area28technologies/io.area28.unity/pull/53