### PR TITLE
feat: export skybox properties to glTF

### DIFF
--- a/Runtime/Scripts/Export/GameObjectExport.cs
+++ b/Runtime/Scripts/Export/GameObjectExport.cs
@@ -87,8 +87,20 @@ namespace GLTFast.Export
             {
                 m_Writer.AddScene(rootNodes.ToArray(), name);
             }
+            ExportSkyboxMaterial();
 
             return success;
+        }
+
+        void ExportSkyboxMaterial()
+        {
+            Material skyboxMaterial = new Material(RenderSettings.skybox);
+            if (skyboxMaterial == null)
+                return;
+
+            skyboxMaterial.name = "Skybox";
+            m_Writer.AddMaterial(
+                skyboxMaterial, out int skyboxMaterialId, m_MaterialExport);
         }
 
         /// <summary>

--- a/Runtime/Scripts/Material/BuiltInMaterialGenerator.cs
+++ b/Runtime/Scripts/Material/BuiltInMaterialGenerator.cs
@@ -261,6 +261,42 @@ namespace GLTFast.Materials
                 shaderMode = StandardShaderMode.Fade;
             }
 
+            Schema.Material.SkyboxData skyboxData = gltfMaterial.extras.skyboxData;
+            if (skyboxData.isSkybox)
+            {
+                switch (skyboxData.skyboxMode)
+                {
+                    case Schema.Material.SkyboxMode.CubeMap:
+                        material.shader = Shader.Find("Skybox/Panoramic");
+                        material.SetColor("_Tint", skyboxData.skyTint);
+                        material.SetFloat("_Exposure", skyboxData.exposure);
+                        material.SetFloat("_Rotation", skyboxData.rotation);
+                        TrySetTexture(
+                            gltfMaterial.pbrMetallicRoughness.baseColorTexture,
+                            material,
+                            gltf,
+                            MainTex,
+                            BaseColorTextureScaleTransformProperty,
+                            BaseColorTextureRotationProperty,
+                            BaseColorTextureTexCoordProperty
+                        );
+                        break;
+                    case Schema.Material.SkyboxMode.Procedural:
+                        material.shader = Shader.Find("Skybox/Procedural");
+                        material.SetColor("_SkyTint", skyboxData.skyTint);
+                        material.SetFloat("_Exposure", skyboxData.exposure);
+                        material.SetFloat("_SunSize", skyboxData.sunSize);
+                        material.SetFloat("_SunSizeConvergence", skyboxData.sunSizeConvergence);
+                        material.SetFloat("_AtmosphereThickness", skyboxData.atmosphereThickness);
+                        material.SetColor("_GroundColor", skyboxData.ground);
+                        break;
+                    default:
+                        Logger?.Warning($"{skyboxData.skyboxMode} skybox mode not supported. Skipping import.");
+                        return null;
+                }
+                RenderSettings.skybox = material;
+            }
+
             if (gltfMaterial.extensions != null)
             {
                 // Specular glossiness

--- a/Runtime/Scripts/Material/MaterialGenerator.cs
+++ b/Runtime/Scripts/Material/MaterialGenerator.cs
@@ -136,6 +136,8 @@ namespace GLTFast.Materials
         public static readonly int NormalTextureTexCoordProperty = Shader.PropertyToID("normalTexture_texCoord");
         /// <summary>Shader property ID for property normalTexture_scale</summary>
         public static readonly int NormalTextureScaleProperty = Shader.PropertyToID("normalTexture_scale");
+        /// <summary>Shader property ID for property _MainTex</summary>
+        public static readonly int MainTex = Shader.PropertyToID("_MainTex");
         /// <summary>Shader property ID for property metallicFactor</summary>
         public static readonly int MetallicProperty = Shader.PropertyToID("metallicFactor");
         /// <summary>Shader property ID for property metallicRoughnessTexture</summary>

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -54,6 +54,32 @@ namespace GLTFast.Schema
         }
 
         /// <summary>
+        /// The material's skybox mode enumeration specifying the type of skybox
+        /// and usage of the attached texture(s)
+        /// </summary>
+        public enum SkyboxMode
+        {
+            /// <summary>
+            /// In 6-sided mode, 6 textures are provided to form the cube map.
+            /// </summary>
+            SixSided,
+
+            /// <summary>
+            /// In cube map mode, a single equi-rectangular texture is used
+            /// to create the cube map. This mode is combined with Unity's
+            /// Panoramic skybox, since the texture usage is the same.
+            /// </summary>
+            CubeMap,
+
+            /// <summary>
+            /// Procedural skyboxes are created with code rather than textures,
+            /// so the relevant properties are specified for skybox replication
+            /// upon import.
+            /// </summary>
+            Procedural
+        }
+
+        /// <summary>
         /// Material extensions.
         /// </summary>
         public MaterialExtension extensions;
@@ -165,6 +191,50 @@ namespace GLTFast.Schema
             }
         }
 
+        [System.Serializable]
+        public struct Extras
+        {
+            public SkyboxData skyboxData;
+
+            public Extras(SkyboxData skyboxData)
+            {
+                this.skyboxData = skyboxData;
+            }
+
+            public override string ToString()
+            {
+                return JsonUtility.ToJson(this);
+            }
+        }
+
+        /// <summary>
+        /// Structure to store skybox material properties
+        /// </summary>
+        [System.Serializable]
+        public struct SkyboxData
+        {
+            public bool isSkybox;
+            public SkyboxMode skyboxMode;
+
+            // Cube map and Panoramic properties
+            public Color skyTint;
+            public float exposure;
+            public float rotation;
+
+            // Procedural skybox properties
+            public float sunSize;
+            public float sunSizeConvergence;
+            public float atmosphereThickness;
+            public Color ground;
+
+            public override string ToString()
+            {
+                return JsonUtility.ToJson(this);
+            }
+        };
+
+        public Extras extras;
+
         /// <summary>
         /// Specifies the cutoff threshold when in `MASK` mode. If the alpha value is greater than
         /// or equal to this value then it is rendered as fully opaque, otherwise, it is rendered
@@ -234,6 +304,10 @@ namespace GLTFast.Schema
             if (doubleSided)
             {
                 writer.AddProperty("doubleSided", doubleSided);
+            }
+            if (extras.skyboxData.isSkybox)
+            {
+                writer.AddProperty("extras", extras);
             }
             if (extensions != null)
             {


### PR DESCRIPTION
ED-1205

Support for Procedural, Cube Map and Panoramic skybox formats. Exported properties are limited because of format issues but basic usage should be fine.

The implementation for Procedural skybox export is hacky, so let me know if it's OK.

This works in conjunction with the skybox importer in the Unity viewer.

No style and format checks for this repository, so I'd appreciate feedback.

Not sure if I should have tests; let me know.