### PR TITLE
ci: move editor-only code to conditionally-compiled block for WebGL build

### DIFF
--- a/Runtime/Scripts/Export/StandardMaterialExport.cs
+++ b/Runtime/Scripts/Export/StandardMaterialExport.cs
@@ -95,14 +95,14 @@ namespace GLTFast.Export
                         material.extras.skyboxData.skyTint = uMaterial.GetColor("_Tint");
                         material.extras.skyboxData.exposure = uMaterial.GetFloat("_Exposure");
                         material.extras.skyboxData.rotation = uMaterial.GetFloat("_Rotation") + 90f;
-
+#if UNITY_EDITOR
                         // Convert texture type to Texture2D
                         string url = UnityEditor.AssetDatabase.GetAssetPath(
                             uMaterial.GetTexture(k_Tex));
                         Texture2D tex = new Texture2D(2, 2);
                         tex.LoadImage(System.IO.File.ReadAllBytes(url));
                         uMaterial.mainTexture = tex;
-
+#endif
                         ExportUnlit(material, uMaterial, k_MainTex, gltf, logger);
                         break;
                     case "Skybox/Panoramic":


### PR DESCRIPTION
In the glTF export code, there is some code that uses Unity editor-only API. This broke the WebGL build, which doesn't support editor code, so I had to fence the offending code away with the `UNITY_EDITOR` directive.