### PR TITLE
feat: handle particles unlit shader and alpha transparent textures

### DIFF
--- a/Editor/Scripts/GltfImporter.cs
+++ b/Editor/Scripts/GltfImporter.cs
@@ -162,9 +162,11 @@ namespace GLTFast.Editor
                     var hasAnimation = false;
 #if UNITY_ANIMATION
                     if (importSettings.AnimationMethod != AnimationMethod.None
-                        && (instantiationSettings.Mask & ComponentType.Animation) != 0) {
+                        && (instantiationSettings.Mask & ComponentType.Animation) != 0)
+                    {
                         var animationClips = m_Gltf.GetAnimationClips();
-                        if (animationClips != null && animationClips.Length > 0) {
+                        if (animationClips != null && animationClips.Length > 0)
+                        {
                             hasAnimation = true;
                         }
                     }
@@ -212,13 +214,12 @@ namespace GLTFast.Editor
                 {
                     var mat = m_Gltf.GetMaterial(i);
 
-                    // Overriding double-sided for GI baking
-                    // Resolves problems with meshes that are not a closed
-                    // volume at a potential minor cost of baking speed.
-                    mat.doubleSidedGI = true;
-
                     if (mat != null)
                     {
+                        // Overriding double-sided for GI baking
+                        // Resolves problems with meshes that are not a closed
+                        // volume at a potential minor cost of baking speed.
+                        mat.doubleSidedGI = true;
                         AddObjectToAsset(ctx, $"materials/{mat.name}", mat);
                     }
                 }
@@ -250,15 +251,19 @@ namespace GLTFast.Editor
 
 #if UNITY_ANIMATION
                 var clips = m_Gltf.GetAnimationClips();
-                if (clips != null) {
-                    foreach (var animationClip in clips) {
-                        if (animationClip == null) {
+                if (clips != null)
+                {
+                    foreach (var animationClip in clips)
+                    {
+                        if (animationClip == null)
+                        {
                             continue;
                         }
-                        if (importSettings.AnimationMethod == AnimationMethod.Mecanim) {
+                        if (importSettings.AnimationMethod == AnimationMethod.Mecanim)
+                        {
                             var settings = AnimationUtility.GetAnimationClipSettings(animationClip);
                             settings.loopTime = true;
-                            AnimationUtility.SetAnimationClipSettings (animationClip, settings);
+                            AnimationUtility.SetAnimationClipSettings(animationClip, settings);
                         }
                         AddObjectToAsset(ctx, $"animations/{animationClip.name}", animationClip);
                     }

--- a/Runtime/Scripts/Export/MaterialExportBase.cs
+++ b/Runtime/Scripts/Export/MaterialExportBase.cs
@@ -123,6 +123,75 @@ namespace GLTFast.Export
         }
 
         /// <summary>
+        /// Retrieves whether material is for a skybox
+        /// </summary>
+        /// <param name="material">Material to analyze</param>
+        /// <returns>True if material uses skybox shader, false otherwise</returns>
+        protected static bool IsSkybox(UnityEngine.Material material)
+        {
+            return material.shader.name.StartsWith("Skybox/");
+        }
+
+        /// <summary>
+        /// Retrieves whether material is unlit
+        /// </summary>
+        /// <param name="material">Material to analyze</param>
+        /// <returns>True if material uses the standard particles unlit shader, false otherwise</returns>
+        protected static bool IsParticlesUnlit(UnityEngine.Material material)
+        {
+            return material.shader.name == "Particles/Standard Unlit";
+        }
+
+        /// <summary>
+        /// Converts an particles unlit Unity material into a glTF material
+        /// </summary>
+        /// <param name="material">Destination glTF material</param>
+        /// <param name="uMaterial">Source Unity material</param>
+        /// <param name="mainTexProperty">Main texture property ID</param>
+        /// <param name="gltf">Context glTF to export to</param>
+        /// <param name="logger">Custom logger</param>
+        protected void ExportParticlesUnlit(
+            Material material,
+            UnityEngine.Material uMaterial,
+            int mainTexProperty,
+            IGltfWritable gltf,
+            ICodeLogger logger
+            )
+        {
+            ExportUnlit(material, uMaterial, mainTexProperty, gltf, logger);
+            var particlesUnlitData = new Material.ParticlesUnlitData { isParticlesUnlit = true };
+
+            particlesUnlitData.color = uMaterial.GetColor("_Color");
+            particlesUnlitData.cutoff = uMaterial.GetFloat("_Cutoff");
+            particlesUnlitData.bumpScale = uMaterial.GetFloat("_BumpScale");
+            particlesUnlitData.emissionColor = uMaterial.GetColor("_EmissionColor");
+            particlesUnlitData.distortionStrength = uMaterial.GetFloat("_DistortionStrength");
+            particlesUnlitData.distortionBlend = uMaterial.GetFloat("_DistortionBlend");
+            particlesUnlitData.softParticlesNearFadeDistance = uMaterial.GetFloat("_SoftParticlesNearFadeDistance");
+            particlesUnlitData.softParticlesFarFadeDistance = uMaterial.GetFloat("_SoftParticlesFarFadeDistance");
+            particlesUnlitData.cameraNearFadeDistance = uMaterial.GetFloat("_CameraNearFadeDistance");
+            particlesUnlitData.cameraFarFadeDistance = uMaterial.GetFloat("_CameraFarFadeDistance");
+            particlesUnlitData.mode = uMaterial.GetFloat("_Mode");
+            particlesUnlitData.colorMode = uMaterial.GetFloat("_ColorMode");
+            particlesUnlitData.flipbookMode = uMaterial.GetFloat("_FlipbookMode");
+            particlesUnlitData.lightingEnabled = uMaterial.GetFloat("_LightingEnabled");
+            particlesUnlitData.distortionEnabled = uMaterial.GetFloat("_DistortionEnabled");
+            particlesUnlitData.emissionEnabled = uMaterial.GetFloat("_EmissionEnabled");
+            particlesUnlitData.blendOp = uMaterial.GetFloat("_BlendOp");
+            particlesUnlitData.srcBlend = uMaterial.GetFloat("_SrcBlend");
+            particlesUnlitData.dstBlend = uMaterial.GetFloat("_DstBlend");
+            particlesUnlitData.zWrite = uMaterial.GetFloat("_ZWrite");
+            particlesUnlitData.cull = uMaterial.GetFloat("_Cull");
+            particlesUnlitData.softParticlesEnabled = uMaterial.GetFloat("_SoftParticlesEnabled");
+            particlesUnlitData.cameraFadingEnabled = uMaterial.GetFloat("_CameraFadingEnabled");
+            particlesUnlitData.softParticleFadeParams = uMaterial.GetVector("_SoftParticleFadeParams");
+            particlesUnlitData.cameraFadeParams = uMaterial.GetVector("_CameraFadeParams");
+            particlesUnlitData.colorAddSubDiff = uMaterial.GetVector("_ColorAddSubDiff");
+            particlesUnlitData.distortionStrengthScaled = uMaterial.GetFloat("_DistortionStrengthScaled");
+            material.extras.particlesUnlitData = particlesUnlitData;
+        }
+
+        /// <summary>
         /// Converts an unlit Unity material into a glTF material
         /// </summary>
         /// <param name="material">Destination glTF material</param>

--- a/Runtime/Scripts/Schema/Material.cs
+++ b/Runtime/Scripts/Schema/Material.cs
@@ -195,11 +195,60 @@ namespace GLTFast.Schema
         public struct Extras
         {
             public SkyboxData skyboxData;
+            public ParticlesUnlitData particlesUnlitData;
 
-            public Extras(SkyboxData skyboxData)
+            public override string ToString()
             {
-                this.skyboxData = skyboxData;
+                string json = "{";
+                if (skyboxData.isSkybox)
+                {
+                    json += $"\"skyboxData\":{skyboxData.ToString()},";
+                }
+                if (particlesUnlitData.isParticlesUnlit)
+                {
+                    json += $"\"particlesUnlitData\":{particlesUnlitData.ToString()}";
+                }
+                json = json.Trim(',') + "}";
+                return json;
             }
+        }
+
+        /// <summary>
+        /// Structure to store skybox material properties
+        /// </summary>
+        [System.Serializable]
+        public struct ParticlesUnlitData
+        {
+            // TODO: handle textures for bumpMap and emissionMap
+            public bool isParticlesUnlit;
+            public Color color;
+            public float cutoff;
+            public float bumpScale;
+            public Color emissionColor;
+            public float distortionStrength;
+            public float distortionBlend;
+            public float softParticlesNearFadeDistance;
+            public float softParticlesFarFadeDistance;
+            public float cameraNearFadeDistance;
+            public float cameraFarFadeDistance;
+
+            public float mode;
+            public float colorMode;
+            public float flipbookMode;
+            public float lightingEnabled;
+            public float distortionEnabled;
+            public float emissionEnabled;
+            public float blendOp;
+            public float srcBlend;
+            public float dstBlend;
+            public float zWrite;
+            public float cull;
+            public float softParticlesEnabled;
+            public float cameraFadingEnabled;
+            public Vector4 softParticleFadeParams;
+            public Vector4 cameraFadeParams;
+            public Vector4 colorAddSubDiff;
+            public float distortionStrengthScaled;
 
             public override string ToString()
             {
@@ -313,7 +362,7 @@ namespace GLTFast.Schema
             {
                 writer.AddProperty("doubleSided", doubleSided);
             }
-            if (extras.skyboxData.isSkybox)
+            if (extras.skyboxData.isSkybox || extras.particlesUnlitData.isParticlesUnlit)
             {
                 writer.AddProperty("extras", extras);
             }


### PR DESCRIPTION
Support exporting the particles unlit shader, and add some hacky way to ensure that alpha transparent textures are still transparent when imported at runtime.

ED-1310