### PR TITLE
refactor: use `Path.Combine` instead of `.Join`

### DIFF
--- a/Runtime/Scripts/Export/ImageExport.cs
+++ b/Runtime/Scripts/Export/ImageExport.cs
@@ -86,7 +86,7 @@ namespace GLTFast.Export
 
             string filename = Path.GetFileName(m_AssetPath);
             string tempdir = Directory.GetParent(FileUtil.GetUniqueTempPathInProject()).FullName;
-            m_AssetPath = Path.Join(tempdir, filename);
+            m_AssetPath = Path.Combine(tempdir, filename);
             File.WriteAllBytes(m_AssetPath, tempTexture.EncodeToPNG());
         }
 #endif


### PR DESCRIPTION
`Path.Join` isn't available in Unity 2020.3.

Oops

no issue