### PR TITLE
fix: add real-time update of environment reflections

### DIFF
--- a/Runtime/Scripts/EnvironmentReflections.cs
+++ b/Runtime/Scripts/EnvironmentReflections.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+public class EnvironmentReflections : MonoBehaviour
+{
+    ReflectionProbe baker;
+
+    public void Start()
+    {
+        AddReflectionProbes();
+        UpdateEnvironment();
+    }
+
+    public void AddReflectionProbes()
+    {
+        baker = gameObject.AddComponent<ReflectionProbe>();
+        baker.cullingMask = 0;
+        baker.refreshMode = ReflectionProbeRefreshMode.ViaScripting;
+        baker.mode = ReflectionProbeMode.Realtime;
+        baker.timeSlicingMode = ReflectionProbeTimeSlicingMode.NoTimeSlicing;
+
+        RenderSettings.defaultReflectionMode = DefaultReflectionMode.Custom;
+    }
+
+    public void UpdateEnvironment() {
+        StartCoroutine(UpdateEnvironmentTask());
+    }
+
+    IEnumerator UpdateEnvironmentTask()
+    {
+        DynamicGI.UpdateEnvironment();
+        baker.RenderProbe();
+        yield return new WaitForEndOfFrame();
+#if UNITY_2022_1_OR_NEWER
+        RenderSettings.customReflectionTexture = baker.texture;
+#else
+        RenderSettings.customReflection = (Cubemap)baker.texture;
+#endif
+    }
+}

--- a/Runtime/Scripts/EnvironmentReflections.cs.meta
+++ b/Runtime/Scripts/EnvironmentReflections.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2c33b9d7fec1cfcd98c5deab4db09af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Material/BuiltInMaterialGenerator.cs
+++ b/Runtime/Scripts/Material/BuiltInMaterialGenerator.cs
@@ -90,6 +90,8 @@ namespace GLTFast.Materials
         static bool s_DefaultMaterialGenerated;
         static Material s_DefaultMaterial;
 
+        EnvironmentReflections reflections;
+
         /// <inheritdoc />
         protected override Material GenerateDefaultMaterial(bool pointsSupport = false)
         {
@@ -376,6 +378,15 @@ namespace GLTFast.Materials
                         return null;
                 }
                 RenderSettings.skybox = material;
+                if (reflections == null)
+                {
+                    GameObject reflectionsObject = new GameObject("EnvironmentReflections");
+                    reflections = reflectionsObject.AddComponent<EnvironmentReflections>();
+                }
+                else
+                {
+                    reflections.UpdateEnvironment();
+                }
             }
 
             if (gltfMaterial.extensions != null)


### PR DESCRIPTION
This would add environment reflections to the scene after the skybox material is updated.

I decided to use the work-around, which is using reflection probes, to get the reflections to work. This solution would add a game object at run time, set up a reflection probe and update the reflection data using the probe.

ED-1408

![image](https://github.com/area28technologies/glTFast/assets/8650202/56660aad-a677-4cbe-8cc0-c870fda777ec)