### PR TITLE
fix: convert TIFF skybox texture to supported format

### DIFF
--- a/Runtime/Scripts/Export/StandardMaterialExport.cs
+++ b/Runtime/Scripts/Export/StandardMaterialExport.cs
@@ -104,8 +104,18 @@ namespace GLTFast.Export
                         skyboxData.exposure = uMaterial.GetFloat("_Exposure");
                         skyboxData.rotation = uMaterial.GetFloat("_Rotation") + 90f;
 #if UNITY_EDITOR
-                        uMaterial.mainTexture =
-                            ResizeTextureToImportSettings(uMaterial.GetTexture(k_Tex));
+                        UnityEngine.Texture texture = uMaterial.GetTexture(k_Tex);
+                        string texturePath = AssetDatabase.GetAssetPath(texture);
+                        string extension = Path.GetExtension(texturePath).ToLower();
+                        if (extension == ".tif" || extension == ".tiff")
+                        {
+                            // convert to jpg
+                            string fileName = TextureUtils.ConvertTexture(texturePath, GLTFast.ImageFormat.Jpeg);
+                            Texture2D texture2d = AssetDatabase.LoadAssetAtPath<Texture2D>(fileName);
+                            texture2d.name = Path.GetFileNameWithoutExtension(fileName);
+                            texture = texture2d;
+                        }
+                        uMaterial.mainTexture = ResizeTextureToImportSettings(texture);
 #endif
                         ExportUnlit(material, uMaterial, k_MainTex, gltf, logger);
                         break;
@@ -115,8 +125,18 @@ namespace GLTFast.Export
                         skyboxData.exposure = uMaterial.GetFloat("_Exposure");
                         skyboxData.rotation = uMaterial.GetFloat("_Rotation");
 #if UNITY_EDITOR
-                        uMaterial.mainTexture =
-                            ResizeTextureToImportSettings(uMaterial.GetTexture(k_MainTex));
+                        texture = uMaterial.GetTexture(k_MainTex);
+                        texturePath = AssetDatabase.GetAssetPath(texture);
+                        extension = Path.GetExtension(texturePath).ToLower();
+                        if (extension == ".tif" || extension == ".tiff")
+                        {
+                            // convert to jpg
+                            string fileName = TextureUtils.ConvertTexture(texturePath, GLTFast.ImageFormat.Jpeg);
+                            Texture2D texture2d = AssetDatabase.LoadAssetAtPath<Texture2D>(fileName);
+                            texture2d.name = Path.GetFileNameWithoutExtension(fileName);
+                            texture = texture2d;
+                        }
+                        uMaterial.mainTexture = ResizeTextureToImportSettings(texture);
 #endif
                         ExportUnlit(material, uMaterial, k_MainTex, gltf, logger);
                         break;
@@ -343,6 +363,7 @@ namespace GLTFast.Export
 #if UNITY_EDITOR
             string texturePath = AssetDatabase.GetAssetPath(texture);
             texture2d.LoadImage(File.ReadAllBytes(texturePath));
+            texture2d.name = Path.GetFileNameWithoutExtension(texturePath);
             TextureImporter textureImporter =
                 (TextureImporter)AssetImporter.GetAtPath(texturePath);
             int maxSize = textureImporter.maxTextureSize;
@@ -362,7 +383,6 @@ namespace GLTFast.Export
                 texture2d.Resize(width, height);
 #endif
                 texture2d.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                texture2d.name = Path.GetFileNameWithoutExtension(texturePath);
                 texture2d.Apply();
             }
 #endif

--- a/Runtime/Scripts/TextureUtils.cs
+++ b/Runtime/Scripts/TextureUtils.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+
+namespace GLTFast
+{
+    static class TextureUtils
+    {
+        internal static string ConvertTexture(string texturePath, ImageFormat format)
+        {
+            string extension = format == ImageFormat.Jpeg ? ".jpg" : ".png";
+            string temp = "Assets/tempTexture" + extension;
+            File.WriteAllBytes(temp, EncodeToFormat(new Texture2D(2, 2), format));
+            AssetDatabase.ImportAsset(temp, ImportAssetOptions.ForceUpdate);
+            TextureImporter textureImporter = AssetImporter.GetAtPath(temp) as TextureImporter;
+            textureImporter.isReadable = true;
+            textureImporter.textureCompression = TextureImporterCompression.Uncompressed;
+            textureImporter.SaveAndReimport();
+
+            File.Copy(texturePath, temp, true);
+            AssetDatabase.ImportAsset(temp, ImportAssetOptions.ForceUpdate);
+            byte[] textureData = EncodeToFormat(AssetDatabase.LoadAssetAtPath<Texture2D>(temp), format);
+
+            string currentExtension = Path.GetExtension(texturePath);
+            string fileName = texturePath.Replace(currentExtension, extension);
+            string projectPath = Directory.GetParent(Application.dataPath).ToString();
+            string fullPath = Path.Combine(projectPath, fileName);
+            File.WriteAllBytes(fullPath, textureData);
+            File.Delete(temp);
+            AssetDatabase.Refresh();
+
+            return fileName;
+        }
+
+        internal static byte[] EncodeToFormat(Texture2D texture, ImageFormat format)
+        {
+            if (format == ImageFormat.Jpeg)
+                return texture.EncodeToJPG(60);
+            if (format == ImageFormat.PNG)
+                return texture.EncodeToPNG();
+            return null;
+        }
+
+    }
+}

--- a/Runtime/Scripts/TextureUtils.cs.meta
+++ b/Runtime/Scripts/TextureUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 407e425dde3bce156816ece3b25f68d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Converted TIFF to JPG, just for this particular case. I'll have to make it more general, and maybe we can choose between PNG and JPG.

Works for the Flamingo scene when I tested.

ED-1517